### PR TITLE
adds `to_dict` methods to time trending classes

### DIFF
--- a/pyRealEstate/Time_Trending.py
+++ b/pyRealEstate/Time_Trending.py
@@ -1,5 +1,7 @@
-from typing import Union, Optional
+from typing import Optional, Any, Callable, Union
 
+import sys
+import decimal
 import numpy as np
 import pandas as pd
 import statsmodels.api as sm
@@ -114,10 +116,22 @@ class SPPSF_Polynomial_Time_Model:
 
         return self.Time_Model.summary()
 
-    def to_dict(self , round_value = 6):
+    def to_dict(self, 
+        precision: Optional[int] = sys.float_info.dig,
+        factor_type: Optional[Callable[Union[int, float], Any]] = decimal.Decimal):
+
+        def _decimal_wrapper(num):
+            return decimal.Decimal(str(num))
+
+        # this is done because the conversion from an int or a float 
+        # to a decimal.Decimal requires one 
+        # additional type conversion and that is to a str
+        if factor_type == decimal.Decimal:
+            factor_type = _decimal_wrapper 
+        
         data = self.Adjustment_Rate_Return(as_pandas=True)
         return {
-            month: round(data['AdjustMent_Rate'][i] ,round_value)
+            month: factor_type(round(data['AdjustMent_Rate'][i] ,precision))
             for i, month in enumerate(data['Months'])
         }
 
@@ -275,16 +289,27 @@ class SPPSF_Machine_Learning_Time_Model:
 
         return self.Time_Model.get_params()
 
-    def to_dict(self , round_value = 6):
+    def to_dict(self, 
+        precision: Optional[int] = sys.float_info.dig,
+        factor_type: Optional[Callable[Union[int, float], Any]] = decimal.Decimal ):
+        def _decimal_wrapper(num):
+            return decimal.Decimal(str(num))
+
+        # this is done because the conversion from an int 
+        # or a float to a decimal.Decimal requires one 
+        # additional type conversion and that is to a str
+        if factor_type == decimal.Decimal:
+            factor_type = _decimal_wrapper
+        
         data = self.Adjustment_Rate_Return(as_pandas=True)
         if self.Return_Gaussian_Smoothing is False:
             return {
-                month: round(data['AdjustMent_Rate'][i] ,round_value)
+                month: factor_type(round(data['AdjustMent_Rate'][i] ,precision))
                 for i, month in enumerate(data['Months'])
             }
 
         return {
-            month: round(data['AdjustMent_Rate_Smoothed'][i] ,round_value)
+            month: factor_type(round(data['AdjustMent_Rate_Smoothed'][i] ,precision))
             for i, month in enumerate(data['Months'])
         }
 
@@ -388,9 +413,21 @@ class MLR_Time_Trend:
         """
         return self.Time_Model.get_params()
     
-    def to_dict(self , round_value = 6):
+    def to_dict(self, 
+        precision: Optional[int] = sys.float_info.dig,
+        factor_type: Optional[Callable[Union[int, float], Any]] = decimal.Decimal):
+            
+        def _decimal_wrapper(num):
+            return decimal.Decimal(str(num))
+        
+        # this is done because the conversion from an int or a float 
+        # to a decimal.Decimal requires one 
+        # additional type conversion and that is to a str
+        if factor_type == decimal.Decimal:
+            factor_type = _decimal_wrapper
+    
         data = self.Adjustment_Rate_Return(as_pandas=True)
         return {
-            month: round(data['AdjustMent_Rate'][i] ,round_value)
+            month: factor_type(round(data['AdjustMent_Rate'][i] ,precision))
             for i, month in enumerate(data['Months'])
         }

--- a/pyRealEstate/Time_Trending.py
+++ b/pyRealEstate/Time_Trending.py
@@ -114,10 +114,10 @@ class SPPSF_Polynomial_Time_Model:
 
         return self.Time_Model.summary()
 
-    def to_dict(self):
+    def to_dict(self , round_value = 6):
         data = self.Adjustment_Rate_Return(as_pandas=True)
         return {
-            month: data['AdjustMent_Rate'][i]
+            month: round(data['AdjustMent_Rate'][i] ,round_value)
             for i, month in enumerate(data['Months'])
         }
 
@@ -275,16 +275,16 @@ class SPPSF_Machine_Learning_Time_Model:
 
         return self.Time_Model.get_params()
 
-    def to_dict(self):
+    def to_dict(self , round_value = 6):
         data = self.Adjustment_Rate_Return(as_pandas=True)
         if self.Return_Gaussian_Smoothing is False:
             return {
-                month: data['AdjustMent_Rate'][i]
+                month: round(data['AdjustMent_Rate'][i] ,round_value)
                 for i, month in enumerate(data['Months'])
             }
 
         return {
-            month: data['AdjustMent_Rate_Smoothed'][i]
+            month: round(data['AdjustMent_Rate_Smoothed'][i] ,round_value)
             for i, month in enumerate(data['Months'])
         }
 
@@ -388,9 +388,9 @@ class MLR_Time_Trend:
         """
         return self.Time_Model.get_params()
     
-    def to_dict(self):
+    def to_dict(self , round_value = 6):
         data = self.Adjustment_Rate_Return(as_pandas=True)
         return {
-            month: data['AdjustMent_Rate'][i]
+            month: round(data['AdjustMent_Rate'][i] ,round_value)
             for i, month in enumerate(data['Months'])
         }

--- a/pyRealEstate/Time_Trending.py
+++ b/pyRealEstate/Time_Trending.py
@@ -114,6 +114,13 @@ class SPPSF_Polynomial_Time_Model:
 
         return self.Time_Model.summary()
 
+    def to_dict(self):
+        data = self.Adjustment_Rate_Return(as_pandas=True)
+        return {
+            month: data['AdjustMent_Rate'][i]
+            for i, month in enumerate(data['Months'])
+        }
+
 
 class SPPSF_Machine_Learning_Time_Model:
 
@@ -268,6 +275,19 @@ class SPPSF_Machine_Learning_Time_Model:
 
         return self.Time_Model.get_params()
 
+    def to_dict(self):
+        data = self.Adjustment_Rate_Return(as_pandas=True)
+        if self.Return_Gaussian_Smoothing is False:
+            return {
+                month: data['AdjustMent_Rate'][i]
+                for i, month in enumerate(data['Months'])
+            }
+
+        return {
+            month: data['AdjustMent_Rate_Smoothed'][i]
+            for i, month in enumerate(data['Months'])
+        }
+
 
 class MLR_Time_Trend:
     """
@@ -367,3 +387,10 @@ class MLR_Time_Trend:
         :rtype: dict
         """
         return self.Time_Model.get_params()
+    
+    def to_dict(self):
+        data = self.Adjustment_Rate_Return(as_pandas=True)
+        return {
+            month: data['AdjustMent_Rate'][i]
+            for i, month in enumerate(data['Months'])
+        }


### PR DESCRIPTION
The purpose of this is for ease of access to a specific monthly factor. Here is a use case example

when setting the price of a comparable property the month the property was sold needs to be adjusted to a specific point in time. This point in time is determined by the assessors office. In my county an assessment is done every odd year. the date range for sales comparisons is from 07/01/assessment year - 3 to 06/30/assessment year - 2 and the date that the sales prices needs to be adjusted to is 06/assessment year - 2. 

By adding the methods to convert the data into a dictionary a comparable is able to have it sales price adjusted easier by using something like the following code.

`time_trend_model` is the model the user has decided to use.
I used the dates I mentioned above in this example.

```python

import datetime
from dateutil import relativedelta

end_date = datetime.datetime(month=6, day=30, year=2022)
sale_date = datetime.datetime(month=comparable_sale_month, day=comparable_sale_day, year=comparable_sale_year)
delta = relativedelta.relativedelta(end_date, sale_date)
months = delta.months + (delta.years * 12)

time_trend_factors = time_trend_model.to_dict()
factor = time_trend_factors[months]

time_adjusted_sale_price = comparable_sale_price * factor
```

There is one issue with this and that is floating point math error that is an inherent problem in Python. There is a solution and that is any numbers that are used in python and are floats they need to be converted to `decimal.Decimal` numbers and then they can be used without causing errors in the numbers.

If you run this code below you will see first hand what I am talking about with floating point math.

```
print(1.2 - 1.0)
```

That produces a result of `0.199999999999999996` which we know is not correct.

The decimal.Decimal library fixes this issue. The number that is passed to the constructor MUST be a string. The only catch to it is you can only perform mathematical operations against other decimal.Decimal numbers they cannot be performed against python ints or floats. Equality testing can be done against ints and floats. 

I recommend that the factors that are set in the dict are made to be decimal.Decimal numbers. If you are OK with that then I will make the changes before you merge the PR
